### PR TITLE
Fix contribution heatmap by wiring React Query provider

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from 'next';
 import { Inter } from 'next/font/google';
 import './globals.css';
 import { cn } from '@/lib/utils';
+import Providers from './providers';
 
 const inter = Inter({ subsets: ['latin'], variable: '--font-sans' });
 
@@ -57,9 +58,11 @@ export default function RootLayout({
           inter.variable
         )}
       >
-        <div className="relative flex min-h-screen flex-col">
-          <main className="flex-1">{children}</main>
-        </div>
+        <Providers>
+          <div className="relative flex min-h-screen flex-col">
+            <main className="flex-1">{children}</main>
+          </div>
+        </Providers>
       </body>
     </html>
   );

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1,0 +1,22 @@
+'use client'
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { ReactNode, useState } from 'react'
+
+interface ProvidersProps {
+  children: ReactNode
+}
+
+export default function Providers({ children }: ProvidersProps) {
+  const [queryClient] = useState(() => new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: 5 * 60 * 1000,
+        retry: 2,
+        refetchOnWindowFocus: false
+      }
+    }
+  }))
+
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+}


### PR DESCRIPTION
## Summary
- add a client-side Providers wrapper that instantiates a shared React Query client with default query settings
- wrap the application layout with the QueryClientProvider so components like the contribution heatmap can safely call useQuery

## Testing
- Not run (dependency installation fails with 403 responses from the npm registry)


------
https://chatgpt.com/codex/tasks/task_e_68cc2ad00ca08322a40bfb32ff016f4c