### PR TITLE
Fix contact form to send emails via Resend

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,14 @@ npm run build
 CONTACT_EMAIL=your@email.com
 GITHUB_URL=https://github.com/yourusername
 LINKEDIN_URL=https://linkedin.com/in/yourprofile
+RESEND_API_KEY=your_resend_api_key
+RESEND_FROM_EMAIL="Sharif Bayoumy <contact@yourdomain.com>"
+RESEND_TO_EMAIL=contact@yourdomain.com
 ```
+
+- `RESEND_API_KEY` is required for the contact form and should be generated from your Resend dashboard.
+- `RESEND_FROM_EMAIL` (optional) must use a verified sender on your Resend domain. If omitted, the app falls back to `Sharif Bayoumy <CONTACT_EMAIL>`.
+- `RESEND_TO_EMAIL` (optional) lets you route contact form messages to a different inbox; it defaults to `CONTACT_EMAIL`.
 
 ### Performance Tuning
 Adjust quality settings in `src/lib/utils.ts`:

--- a/scripts/deployment-checklist.md
+++ b/scripts/deployment-checklist.md
@@ -40,6 +40,7 @@
 - [ ] `SENTRY_ORG` - Sentry organization
 - [ ] `SENTRY_PROJECT` - Sentry project name
 - [ ] `CONTACT_EMAIL` - Contact email address
+- [ ] `RESEND_API_KEY` - Resend API key for contact form
 - [ ] `GITHUB_URL` - GitHub profile URL
 - [ ] `LINKEDIN_URL` - LinkedIn profile URL
 
@@ -48,6 +49,8 @@
 - [ ] `LIGHTHOUSE_TOKEN` - Performance monitoring
 - [ ] `SLACK_WEBHOOK_URL` - Deployment notifications
 - [ ] `DATADOG_API_KEY` - Custom metrics
+- [ ] `RESEND_FROM_EMAIL` - Custom verified sender address
+- [ ] `RESEND_TO_EMAIL` - Override contact form recipient
 
 ### Domain & SSL
 - [ ] Custom domain configured (if applicable)

--- a/scripts/vercel-env-sync.js
+++ b/scripts/vercel-env-sync.js
@@ -19,6 +19,7 @@ class VercelEnvSync {
       'SENTRY_ORG',
       'SENTRY_PROJECT',
       'CONTACT_EMAIL',
+      'RESEND_API_KEY',
       'GITHUB_URL',
       'LINKEDIN_URL'
     ];
@@ -28,7 +29,9 @@ class VercelEnvSync {
       'SLACK_WEBHOOK_URL',
       'DISCORD_WEBHOOK_URL',
       'DATADOG_API_KEY',
-      'DEPLOYMENT_WEBHOOK_URL'
+      'DEPLOYMENT_WEBHOOK_URL',
+      'RESEND_FROM_EMAIL',
+      'RESEND_TO_EMAIL'
     ];
   }
 

--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -1,0 +1,188 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+
+export const runtime = 'nodejs';
+
+const PROJECT_TYPE_LABELS: Record<string, string> = {
+  xr: 'XR/VR/AR Development',
+  web: 'Web Development',
+  game: 'Game Development',
+  ai: 'AI/ML Integration',
+  research: 'Research Project',
+};
+
+const BUDGET_LABELS: Record<string, string> = {
+  'under-5k': 'Under €5K',
+  '5k-15k': '€5K - €15K',
+  '15k-50k': '€15K - €50K',
+  '50k-plus': '€50K+',
+  discuss: "Let's discuss",
+};
+
+const TIMELINE_LABELS: Record<string, string> = {
+  asap: 'ASAP',
+  '1-3-months': '1-3 months',
+  '3-6-months': '3-6 months',
+  '6-12-months': '6-12 months',
+  'long-term': 'Long-term project',
+};
+
+const ContactFormSchema = z.object({
+  name: z.string().trim().min(1, 'Name is required').max(100, 'Name is too long'),
+  email: z
+    .string()
+    .trim()
+    .email('Please provide a valid email address')
+    .max(320, 'Email address is too long'),
+  subject: z.string().trim().min(1, 'Subject is required').max(200, 'Subject is too long'),
+  message: z.string().trim().min(1, 'Message is required').max(5000, 'Message is too long'),
+  projectType: z
+    .enum(['xr', 'web', 'game', 'ai', 'research'] as const)
+    .optional(),
+  budget: z
+    .enum(['under-5k', '5k-15k', '15k-50k', '50k-plus', 'discuss'] as const)
+    .optional(),
+  timeline: z
+    .enum(['asap', '1-3-months', '3-6-months', '6-12-months', 'long-term'] as const)
+    .optional(),
+});
+
+type ContactFormPayload = z.infer<typeof ContactFormSchema>;
+
+const escapeHtml = (value: string): string =>
+  value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+
+const formatMultiline = (value: string): string => escapeHtml(value).replace(/\r?\n/g, '<br />');
+
+const getDisplayValue = (value: string | undefined, labels: Record<string, string>): string => {
+  if (!value) {
+    return 'Not specified';
+  }
+
+  return labels[value] ?? value;
+};
+
+const buildHtmlBody = (data: ContactFormPayload, submittedAt: string) => {
+  return `
+    <div style="font-family: 'Inter', Arial, sans-serif; background-color: #0b1120; padding: 24px;">
+      <div style="max-width: 640px; margin: 0 auto; background-color: rgba(15, 23, 42, 0.85); border: 1px solid rgba(148, 163, 184, 0.2); border-radius: 16px; padding: 24px; color: #e2e8f0;">
+        <h2 style="margin: 0 0 16px; font-size: 20px; color: #38bdf8;">New contact from sharifbayoumy.com</h2>
+        <p style="margin: 0 0 24px; color: #cbd5f5;">You received a new message from your portfolio contact form.</p>
+        <div style="display: grid; gap: 12px; margin-bottom: 24px;">
+          <div><strong style="display: block; color: #94a3b8;">Name</strong><span style="color: #f8fafc;">${escapeHtml(
+            data.name
+          )}</span></div>
+          <div><strong style="display: block; color: #94a3b8;">Email</strong><span style="color: #f8fafc;">${escapeHtml(
+            data.email
+          )}</span></div>
+          <div><strong style="display: block; color: #94a3b8;">Subject</strong><span style="color: #f8fafc;">${escapeHtml(
+            data.subject
+          )}</span></div>
+          <div><strong style="display: block; color: #94a3b8;">Project Type</strong><span style="color: #f8fafc;">${escapeHtml(
+            getDisplayValue(data.projectType, PROJECT_TYPE_LABELS)
+          )}</span></div>
+          <div><strong style="display: block; color: #94a3b8;">Budget</strong><span style="color: #f8fafc;">${escapeHtml(
+            getDisplayValue(data.budget, BUDGET_LABELS)
+          )}</span></div>
+          <div><strong style="display: block; color: #94a3b8;">Timeline</strong><span style="color: #f8fafc;">${escapeHtml(
+            getDisplayValue(data.timeline, TIMELINE_LABELS)
+          )}</span></div>
+          <div><strong style="display: block; color: #94a3b8;">Submitted</strong><span style="color: #f8fafc;">${escapeHtml(
+            submittedAt
+          )}</span></div>
+        </div>
+        <div style="border-top: 1px solid rgba(148, 163, 184, 0.2); padding-top: 16px;">
+          <strong style="display: block; margin-bottom: 8px; color: #94a3b8;">Message</strong>
+          <p style="white-space: pre-wrap; margin: 0; color: #f8fafc; line-height: 1.8;">${formatMultiline(data.message)}</p>
+        </div>
+      </div>
+    </div>
+  `;
+};
+
+const buildTextBody = (data: ContactFormPayload, submittedAt: string) => {
+  return [
+    'New contact from sharifbayoumy.com',
+    '',
+    `Name: ${data.name}`,
+    `Email: ${data.email}`,
+    `Subject: ${data.subject}`,
+    `Project Type: ${getDisplayValue(data.projectType, PROJECT_TYPE_LABELS)}`,
+    `Budget: ${getDisplayValue(data.budget, BUDGET_LABELS)}`,
+    `Timeline: ${getDisplayValue(data.timeline, TIMELINE_LABELS)}`,
+    `Submitted: ${submittedAt}`,
+    '',
+    'Message:',
+    data.message,
+  ].join('\n');
+};
+
+export async function POST(request: Request) {
+  try {
+    const payload = await request.json();
+    const parsed = ContactFormSchema.safeParse(payload);
+
+    if (!parsed.success) {
+      const message = parsed.error.issues.map(issue => issue.message).join(', ') || 'Invalid form submission.';
+      return NextResponse.json({ error: message }, { status: 400 });
+    }
+
+    const apiKey = process.env.RESEND_API_KEY;
+
+    if (!apiKey) {
+      console.error('RESEND_API_KEY is not configured.');
+      return NextResponse.json({ error: 'Email service is not configured.' }, { status: 500 });
+    }
+
+    const contactEmail = process.env.CONTACT_EMAIL || 'contact@sharifbayoumy.com';
+    const fromEmail = process.env.RESEND_FROM_EMAIL || `Sharif Bayoumy <${contactEmail}>`;
+    const toEmail = process.env.RESEND_TO_EMAIL || contactEmail;
+    const submittedAt = new Date().toUTCString();
+
+    const emailPayload = {
+      from: fromEmail,
+      to: [toEmail],
+      reply_to: parsed.data.email,
+      subject: `New portfolio inquiry: ${parsed.data.subject}`,
+      html: buildHtmlBody(parsed.data, submittedAt),
+      text: buildTextBody(parsed.data, submittedAt),
+      tags: [
+        { name: 'source', value: 'portfolio-contact-form' },
+        {
+          name: 'environment',
+          value: process.env.VERCEL_ENV || process.env.NODE_ENV || 'development',
+        },
+      ],
+    };
+
+    const resendResponse = await fetch('https://api.resend.com/emails', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+      body: JSON.stringify(emailPayload),
+    });
+
+    if (!resendResponse.ok) {
+      const errorPayload = await resendResponse.json().catch(() => null);
+      const errorMessage =
+        (errorPayload && (errorPayload.message || errorPayload.error || errorPayload?.details?.[0]?.message)) ||
+        `Failed to send message (status ${resendResponse.status})`;
+
+      console.error('Resend API error:', errorPayload || resendResponse.statusText);
+      return NextResponse.json({ error: errorMessage }, { status: 502 });
+    }
+
+    return NextResponse.json({ message: 'Message sent successfully.' });
+  } catch (error) {
+    console.error('Contact form submission failed:', error);
+    return NextResponse.json({ error: 'Unable to send message at this time.' }, { status: 500 });
+  }
+}

--- a/src/components/sections/contact-section.tsx
+++ b/src/components/sections/contact-section.tsx
@@ -37,17 +37,43 @@ export default function ContactSection() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    setSubmitStatus('idle');
     setIsSubmitting(true);
-    
+
     try {
-      // Simulate API call - replace with actual implementation
-      await new Promise(resolve => setTimeout(resolve, 2000));
-      
-      // For now, just open email client
-      const emailBody = `Name: ${formData.name}%0D%0AEmail: ${formData.email}%0D%0ASubject: ${formData.subject}%0D%0AProject Type: ${formData.projectType || 'Not specified'}%0D%0ABudget: ${formData.budget || 'Not specified'}%0D%0ATimeline: ${formData.timeline || 'Not specified'}%0D%0A%0D%0AMessage:%0D%0A${formData.message}`;
-      
-      window.open(`mailto:contact@sharifbayoumy.com?subject=${encodeURIComponent(formData.subject)}&body=${emailBody}`);
-      
+      const payload: Record<string, string> = {
+        name: formData.name.trim(),
+        email: formData.email.trim(),
+        subject: formData.subject.trim(),
+        message: formData.message.trim(),
+      };
+
+      if (formData.projectType) {
+        payload.projectType = formData.projectType;
+      }
+
+      if (formData.budget) {
+        payload.budget = formData.budget;
+      }
+
+      if (formData.timeline) {
+        payload.timeline = formData.timeline;
+      }
+
+      const response = await fetch('/api/contact', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(payload),
+      });
+
+      const result = (await response.json().catch(() => null)) as { message?: string; error?: string } | null;
+
+      if (!response.ok) {
+        throw new Error(result?.error || 'Failed to send message');
+      }
+
       setSubmitStatus('success');
       setFormData({
         name: '',
@@ -59,6 +85,7 @@ export default function ContactSection() {
         timeline: undefined,
       });
     } catch (error) {
+      console.error('Failed to submit contact form', error);
       setSubmitStatus('error');
     } finally {
       setIsSubmitting(false);
@@ -66,11 +93,40 @@ export default function ContactSection() {
     }
   };
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
-    setFormData(prev => ({
-      ...prev,
-      [e.target.name]: e.target.value,
-    }));
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>
+  ) => {
+    const { name, value } = e.target;
+
+    setFormData(prev => {
+      switch (name) {
+        case 'projectType':
+          return {
+            ...prev,
+            projectType: value === '' ? undefined : (value as ContactFormData['projectType']),
+          };
+        case 'budget':
+          return {
+            ...prev,
+            budget: value === '' ? undefined : (value as ContactFormData['budget']),
+          };
+        case 'timeline':
+          return {
+            ...prev,
+            timeline: value === '' ? undefined : (value as ContactFormData['timeline']),
+          };
+        case 'name':
+          return { ...prev, name: value };
+        case 'email':
+          return { ...prev, email: value };
+        case 'subject':
+          return { ...prev, subject: value };
+        case 'message':
+          return { ...prev, message: value };
+        default:
+          return prev;
+      }
+    });
   };
 
   const contactInfo = [


### PR DESCRIPTION
## Summary
- add a `/api/contact` route that validates submissions and sends emails through Resend with HTML/text templates
- update the contact section to POST form data, normalize optional fields, and surface submission errors
- document the new Resend environment variables and sync them into deployment automation scripts

## Testing
- `bun run lint` *(fails: registry access returned 403 so dependencies could not be installed)*
- `bun run type-check` *(fails: missing dependencies because registry access returned 403)*

------
https://chatgpt.com/codex/tasks/task_e_68cc2b2b3f648322b8c33c6c00d0dd71