### PR TITLE
Adjust nav positioning and hero spacing

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -81,6 +81,10 @@
   .scroll-smooth {
     scroll-behavior: smooth;
   }
+
+  .section-anchor-offset {
+    scroll-margin-top: calc(env(safe-area-inset-top, 0px) + clamp(4rem, 8vw, 6rem));
+  }
   
   /* WebGL Error Fallback */
   .no-webgl {

--- a/src/components/github-visualizers/GitHubVisualizersSection.tsx
+++ b/src/components/github-visualizers/GitHubVisualizersSection.tsx
@@ -44,7 +44,7 @@ export default function GitHubVisualizersSection() {
 
   if (error) {
     return (
-      <section className="relative py-20 px-4 sm:px-6 lg:px-8" id="github-stats">
+      <section className="section-anchor-offset relative py-20 px-4 sm:px-6 lg:px-8" id="github-stats">
         <div className="max-w-7xl mx-auto text-center">
           <div className="glass-morphism p-8 rounded-xl">
             <Github className="w-12 h-12 text-red-400 mx-auto mb-4" />
@@ -65,7 +65,7 @@ export default function GitHubVisualizersSection() {
   return (
     <section
       ref={ref}
-      className="relative py-20 px-4 sm:px-6 lg:px-8 bg-gradient-to-b from-transparent via-slate-900/10 to-transparent"
+      className="section-anchor-offset relative py-20 px-4 sm:px-6 lg:px-8 bg-gradient-to-b from-transparent via-slate-900/10 to-transparent"
       id="github-stats"
     >
       <div className="max-w-7xl mx-auto">

--- a/src/components/linkedin-visualizers/LinkedInVisualizersSection.tsx
+++ b/src/components/linkedin-visualizers/LinkedInVisualizersSection.tsx
@@ -51,7 +51,7 @@ export default function LinkedInVisualizersSection() {
 
   if (error) {
     return (
-      <section id="linkedin-visualizers" className="py-20 px-4 sm:px-6 lg:px-8">
+      <section id="linkedin-visualizers" className="section-anchor-offset py-20 px-4 sm:px-6 lg:px-8">
         <div className="max-w-7xl mx-auto">
           <div className="text-center">
             <motion.div
@@ -284,7 +284,7 @@ export default function LinkedInVisualizersSection() {
   };
 
   return (
-    <section id="linkedin-visualizers" className="py-20 px-4 sm:px-6 lg:px-8">
+    <section id="linkedin-visualizers" className="section-anchor-offset py-20 px-4 sm:px-6 lg:px-8">
       <div className="max-w-7xl mx-auto">
         {/* Section Header */}
         <motion.div

--- a/src/components/navigation/floating-nav.tsx
+++ b/src/components/navigation/floating-nav.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { motion, AnimatePresence, useMotionValue, useSpring } from 'framer-motion';
+import { motion, AnimatePresence, useMotionValue, useSpring, useTransform } from 'framer-motion';
 import { Home, User, Briefcase, Github, Linkedin as LinkedinIcon, Mail, Menu, X } from 'lucide-react';
 
 
@@ -30,7 +30,10 @@ export default function FloatingNav() {
   const smoothScrollProgress = useSpring(scrollProgress, { stiffness: 120, damping: 20 });
   const topOffset = useMotionValue(24); // px, default top-6
   const smoothTopOffset = useSpring(topOffset, { stiffness: 120, damping: 20 });
+  const safeTopOffset = useTransform(smoothTopOffset, (value) => `calc(env(safe-area-inset-top, 0px) + ${value}px)`);
   const [isScrolled, setIsScrolled] = useState(false);
+  const mobileTriggerTop = 'calc(env(safe-area-inset-top, 0px) + 1rem)';
+  const mobileMenuTop = 'calc(env(safe-area-inset-top, 0px) + 5rem)';
 
   useEffect(() => {
     const handleScroll = () => {
@@ -82,12 +85,16 @@ export default function FloatingNav() {
         className={
           'fixed left-1/2 transform -translate-x-1/2 z-50 hidden md:block transition-all duration-300'
         }
-        style={{ top: smoothTopOffset }}
+        style={{ top: safeTopOffset }}
         initial={{ y: -100, opacity: 0 }}
         animate={{ y: 0, opacity: 1 }}
         transition={{ duration: 0.8, ease: 'easeOut' }}
       >
-        <div className="bg-black/40 backdrop-blur-md border border-white/10 rounded-2xl px-6 py-3 shadow-2xl">
+        <div
+          className={`backdrop-blur-md rounded-2xl px-6 py-3 shadow-2xl border transition-colors duration-300 ${
+            isScrolled ? 'bg-black/70 border-white/20' : 'bg-black/40 border-white/10'
+          }`}
+        >
           <div className="flex items-center space-x-1">
             {navItems.map((item) => {
               const isActive = activeSection === item.id;
@@ -128,7 +135,8 @@ export default function FloatingNav() {
 
       {/* Mobile Navigation */}
       <motion.div
-        className="fixed top-4 right-4 z-50 md:hidden"
+        className="fixed right-4 z-50 md:hidden"
+        style={{ top: mobileTriggerTop }}
         initial={{ scale: 0, opacity: 0 }}
         animate={{ scale: 1, opacity: 1 }}
         transition={{ duration: 0.5, delay: 0.2 }}
@@ -180,7 +188,8 @@ export default function FloatingNav() {
 
             {/* Menu Panel */}
             <motion.div
-              className="fixed top-20 right-4 z-50 md:hidden"
+              className="fixed right-4 z-50 md:hidden"
+              style={{ top: mobileMenuTop }}
               initial={{ scale: 0.8, opacity: 0, y: -20 }}
               animate={{ scale: 1, opacity: 1, y: 0 }}
               exit={{ scale: 0.8, opacity: 0, y: -20 }}
@@ -256,7 +265,7 @@ export default function FloatingNav() {
       {/* Progress Indicator */}
       <motion.div
         className="fixed top-0 left-0 right-0 h-1 bg-gradient-to-r from-purple-500 via-blue-500 to-cyan-500 z-50 origin-left"
-        style={{ scaleX: smoothScrollProgress }}
+        style={{ scaleX: smoothScrollProgress, top: 'env(safe-area-inset-top, 0px)' }}
         initial={{ scaleX: 0 }}
         transition={{ duration: 0.1 }}
       />

--- a/src/components/sections/about-section.tsx
+++ b/src/components/sections/about-section.tsx
@@ -142,7 +142,7 @@ export default function AboutSection() {
   return (
     <section
       ref={ref}
-      className="relative py-20 px-4 sm:px-6 lg:px-8 bg-gradient-to-b from-transparent via-slate-900/20 to-transparent"
+      className="section-anchor-offset relative py-20 px-4 sm:px-6 lg:px-8 bg-gradient-to-b from-transparent via-slate-900/20 to-transparent"
       id="about"
     >
       <div className="max-w-7xl mx-auto">

--- a/src/components/sections/contact-section.tsx
+++ b/src/components/sections/contact-section.tsx
@@ -197,7 +197,7 @@ export default function ContactSection() {
   return (
     <section
       ref={ref}
-      className="relative py-20 px-4 sm:px-6 lg:px-8"
+      className="section-anchor-offset relative py-20 px-4 sm:px-6 lg:px-8"
       id="contact"
     >
       <div className="max-w-6xl mx-auto">

--- a/src/components/sections/hero-section.tsx
+++ b/src/components/sections/hero-section.tsx
@@ -18,6 +18,9 @@ export default function HeroSection() {
 
   if (!mounted) return null;
 
+  const heroPaddingTop = 'calc(env(safe-area-inset-top, 0px) + clamp(4rem, 8vw, 6.5rem))';
+  const heroPaddingBottom = 'clamp(3rem, 6vw, 5rem)';
+
   const containerVariants = {
     hidden: { opacity: 0 },
     visible: {
@@ -55,8 +58,9 @@ export default function HeroSection() {
   return (
     <section
       ref={ref}
-      className="relative min-h-screen flex items-center justify-center px-4 sm:px-6 lg:px-8"
+      className="section-anchor-offset relative flex min-h-screen items-center justify-center px-4 sm:px-6 lg:px-8"
       id="hero"
+      style={{ paddingTop: heroPaddingTop, paddingBottom: heroPaddingBottom }}
     >
       {/* Background Glow Effects */}
       <div className="absolute inset-0 overflow-hidden pointer-events-none">
@@ -245,7 +249,8 @@ export default function HeroSection() {
 
       {/* Interactive VR Headset Hint */}
       <motion.div
-        className="absolute bottom-10 left-10 hidden lg:block"
+        className="absolute left-10 hidden lg:block"
+        style={{ bottom: 'calc(env(safe-area-inset-bottom, 0px) + 2.5rem)' }}
         initial={{ opacity: 0, scale: 0.8 }}
         animate={{ opacity: 1, scale: 1 }}
         transition={{ delay: 2, duration: 0.8 }}

--- a/src/components/sections/projects-section.tsx
+++ b/src/components/sections/projects-section.tsx
@@ -157,7 +157,7 @@ export default function ProjectsSection() {
   return (
     <section
       ref={ref}
-      className="relative py-20 px-4 sm:px-6 lg:px-8"
+      className="section-anchor-offset relative py-20 px-4 sm:px-6 lg:px-8"
       id="projects"
     >
       <div className="max-w-7xl mx-auto">


### PR DESCRIPTION
## Summary
- update the floating navigation to respect safe-area insets, improve scroll styling, and steady the mobile trigger/menu offsets
- lower the hero section with responsive safe-area-aware padding and adjust the VR hint placement
- add a shared section anchor offset utility and apply it across major sections for consistent scroll positions

## Testing
- npm run lint
- npm run type-check

------
https://chatgpt.com/codex/tasks/task_e_68ccf9bda78c8322b9ae9b729f04e8f9